### PR TITLE
Enhance project structure and add training utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# Python caches
+__pycache__/
+*.pyc
+
+# Virtual environments
+.env/
+venv/
+
+# Data and model outputs
+model_output/
+*.png
+
+# Temporary or system files
+.cache/
+.browser_data_dir/
+.pki/
+.secrets/
+.npm/
+.local/

--- a/README.md
+++ b/README.md
@@ -27,15 +27,25 @@ The modules rely on the HuggingFace `transformers` library. You can edit each co
 
 ## Extending the Pipeline
 The project follows a simple structure so new functionality can be added easily:
-- `research_workflow/` – topic selection utilities
-- `digital_literacy/` – source evaluation and academic search
-- `simulation_lab/` – physics/biology simulations and data generation
-- `assessment/` – rubric-based grading tools
-- `peer_collab/` – collaboration server for shared notes and feedback
-- `security/` – user authentication and ethical flagging
-- `data/` – helpers for loading and tokenizing datasets
+* `research_workflow/` – topic selection utilities
+* `digital_literacy/` – source evaluation and academic search
+* `simulation_lab/` – physics/biology simulations and data generation
+* `assessment/` – rubric-based grading tools
+* `peer_collab/` – collaboration server for shared notes and feedback
+* `security/` – user authentication and ethical flagging
+* `data/` – helpers for loading and tokenizing datasets
+* `models/` – wrappers around HuggingFace models
+* `train/` – simple training loops
 
-New training loops, datasets or evaluation scripts can be added under new modules, keeping the code organized as described in `AGENTS.md`.
+The new `train` module contains utilities for fine-tuning language models with
+CUDA support. Run a basic training job as follows:
+
+```bash
+python3 -m train.trainer --help
+```
+
+New training loops, datasets or evaluation scripts can be added under these
+modules, keeping the code organized as described in `AGENTS.md`.
 
 ## License
 This repository is provided for research and experimentation purposes only.

--- a/data/dataset_loader.py
+++ b/data/dataset_loader.py
@@ -1,3 +1,6 @@
+
+"""Dataset loading and tokenization utilities."""
+
 from typing import Any
 from datasets import load_dataset, Dataset
 from transformers import AutoTokenizer

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 
+"""Entry point demonstrating the various SelfResearch modules."""
+
 import torch
-import os
 
 from research_workflow.topic_selector import TopicSelector
 from digital_literacy.source_evaluator import SourceEvaluator

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+# This package contains model wrappers

--- a/models/model_wrapper.py
+++ b/models/model_wrapper.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Model wrapper utilities for HuggingFace models."""
+
+from typing import Optional
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class LanguageModelWrapper:
+    """Simple wrapper around a causal language model."""
+
+    def __init__(self, model_name: str, device: Optional[str] = None) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    def generate(self, prompt: str, max_new_tokens: int = 50) -> str:
+        """Generate text from a prompt."""
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            outputs = self.model.generate(**inputs, max_new_tokens=max_new_tokens)
+        return self.tokenizer.decode(outputs[0], skip_special_tokens=True)

--- a/train/__init__.py
+++ b/train/__init__.py
@@ -1,0 +1,1 @@
+# Training loop utilities

--- a/train/trainer.py
+++ b/train/trainer.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+"""Simple training utilities for language models."""
+
+from dataclasses import dataclass
+from typing import Optional
+import argparse
+
+import torch
+from transformers import (AutoModelForCausalLM, AutoTokenizer, Trainer,
+                          TrainingArguments)
+
+from data.dataset_loader import load_and_tokenize
+
+
+@dataclass
+class TrainingConfig:
+    """Configuration for model training."""
+
+    model_name: str
+    dataset_name: str
+    split: str
+    output_dir: str = "./model_output"
+    epochs: int = 1
+    batch_size: int = 2
+    lr: float = 5e-5
+    device: Optional[str] = None
+
+
+def train_model(config: TrainingConfig) -> None:
+    """Train a causal language model using HuggingFace Trainer."""
+    device = torch.device(config.device or ("cuda" if torch.cuda.is_available() else "cpu"))
+    tokenized_ds = load_and_tokenize(config.dataset_name, config.split, config.model_name)
+    model = AutoModelForCausalLM.from_pretrained(config.model_name).to(device)
+    tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+
+    training_args = TrainingArguments(
+        output_dir=config.output_dir,
+        num_train_epochs=config.epochs,
+        per_device_train_batch_size=config.batch_size,
+        learning_rate=config.lr,
+        logging_steps=10,
+        save_steps=50,
+        report_to="none",
+    )
+
+    trainer = Trainer(model=model, args=training_args, train_dataset=tokenized_ds, tokenizer=tokenizer)
+    trainer.train()
+    trainer.save_model(config.output_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train a causal language model")
+    parser.add_argument("model_name", help="Model identifier from the HuggingFace hub")
+    parser.add_argument("dataset", help="Dataset name from the HuggingFace hub")
+    parser.add_argument("split", help="Dataset split, e.g. 'train[:100]'")
+    parser.add_argument("--epochs", type=int, default=1, help="Number of training epochs")
+    parser.add_argument("--batch-size", type=int, default=2, help="Batch size")
+    parser.add_argument("--output-dir", default="./model_output", help="Directory to save the model")
+    args = parser.parse_args()
+
+    config = TrainingConfig(
+        model_name=args.model_name,
+        dataset_name=args.dataset,
+        split=args.split,
+        output_dir=args.output_dir,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+    )
+    train_model(config)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `.gitignore` to prevent temporary directories from being tracked
- expand `README` with new modules and basic training usage
- add module docstrings to data loader and main script
- introduce `models/` with a simple language model wrapper
- introduce `train/` with a CLI training utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496b696dc08331834490dec31ff1b8