### PR TITLE
Enhance training utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ model_output/
 .secrets/
 .npm/
 .local/
+.pytest_cache/
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ The project follows a simple structure so new functionality can be added easily:
 * `models/` – wrappers around HuggingFace models
 * `train/` – simple training loops
 
-The new `train` module contains utilities for fine-tuning language models with
-CUDA support. Run a basic training job as follows:
+The `train` module contains utilities for fine-tuning language models with
+CUDA support. Training now accepts separate train and evaluation splits and
+reports perplexity after each epoch. Run `--help` to see all options:
 
 ```bash
 python3 -m train.trainer --help

--- a/data/dataset_loader.py
+++ b/data/dataset_loader.py
@@ -1,32 +1,85 @@
 
 """Dataset loading and tokenization utilities."""
 
-from typing import Any
-from datasets import load_dataset, Dataset
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+from datasets import Dataset, load_dataset
 from transformers import AutoTokenizer
 
-def load_and_tokenize(dataset_name: str, split: str, tokenizer_name: str, batch_size: int = 1000) -> Dataset:
-    """Load a dataset from HuggingFace Hub and tokenize it using a specified tokenizer.
+
+def load_and_tokenize(
+    dataset_name: str,
+    split: str,
+    tokenizer_name: str,
+    text_column: str = "text",
+    batch_size: int = 1000,
+) -> Dataset:
+    """Load a dataset from the HuggingFace Hub and tokenize it.
 
     Args:
-        dataset_name: Name of the dataset to load (e.g., "ag_news").
-        split: Which split to load (e.g., "train[:1000]").
+        dataset_name: Name or path of the dataset to load (e.g. ``"ag_news"``).
+        split: Which split to load (e.g. ``"train[:1000]"``).
         tokenizer_name: Name of the tokenizer/model to tokenize with.
+        text_column: Name of the text column to tokenize.
         batch_size: Batch size for tokenization.
 
     Returns:
-        A tokenized dataset formatted with PyTorch tensors.
+        The tokenized dataset formatted with PyTorch tensors.
     """
     dataset = load_dataset(dataset_name, split=split)
     tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
 
     def tokenize(batch: Any) -> Any:
-        return tokenizer(batch["text"], padding="max_length", truncation=True)
+        return tokenizer(batch[text_column], padding="max_length", truncation=True)
 
     tokenized = dataset.map(tokenize, batched=True, batch_size=batch_size)
     tokenized.set_format(type="torch", columns=["input_ids", "attention_mask"])
     return tokenized
 
+
+def load_dataset_splits(
+    dataset_name: str,
+    tokenizer_name: str,
+    train_split: str = "train",
+    eval_split: Optional[str] = None,
+    text_column: str = "text",
+    batch_size: int = 1000,
+) -> Tuple[Dataset, Optional[Dataset]]:
+    """Load and tokenize train/eval dataset splits.
+
+    Args:
+        dataset_name: Dataset name or local path.
+        tokenizer_name: Pretrained tokenizer name.
+        train_split: Split for training data.
+        eval_split: Optional evaluation split.
+        text_column: Name of the text column to tokenize.
+        batch_size: Batch size for tokenization.
+
+    Returns:
+        A tuple of ``(train_dataset, eval_dataset)`` where ``eval_dataset`` may
+        be ``None`` if ``eval_split`` is not provided.
+    """
+    train_ds = load_and_tokenize(
+        dataset_name,
+        train_split,
+        tokenizer_name,
+        text_column=text_column,
+        batch_size=batch_size,
+    )
+    eval_ds = None
+    if eval_split:
+        eval_ds = load_and_tokenize(
+            dataset_name,
+            eval_split,
+            tokenizer_name,
+            text_column=text_column,
+            batch_size=batch_size,
+        )
+    return train_ds, eval_ds
+
+
 if __name__ == "__main__":
-    ds = load_and_tokenize("ag_news", "train[:10]", "distilgpt2")
+    ds, _ = load_dataset_splits("ag_news", "distilgpt2", train_split="train[:10]")
     print(ds[0])


### PR DESCRIPTION
## Summary
- improve dataset loader with train/eval split support
- extend trainer to handle evaluation and report perplexity
- document new training options in the README
- ignore more temporary directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496d3827dc8331b14b5f0618203d91