### PR TITLE
Improve dataset loader and training logging

### DIFF
--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -1,11 +1,11 @@
 from unittest.mock import patch
 from datasets import Dataset
 
-from data.dataset_loader import load_and_tokenize
+from data.dataset_loader import load_and_tokenize, load_local_json_dataset
 
 
 class DummyTokenizer:
-    def __call__(self, text, truncation=True, padding="max_length"):
+    def __call__(self, text, truncation=True, padding="max_length", **kwargs):
         if isinstance(text, list):
             return {"input_ids": [[1, 2]] * len(text), "attention_mask": [[1, 1]] * len(text)}
         return {"input_ids": [1, 2], "attention_mask": [1, 1]}
@@ -32,3 +32,14 @@ def test_load_and_tokenize_cache(tmp_path):
         tokenized2 = load_and_tokenize("dummy", "train", "dummy", cache_dir=str(tmp_path))
         load_disk_mock.assert_called_once()
         load_ds_mock.assert_not_called()
+
+
+def test_load_local_json_dataset(tmp_path):
+    json_file = tmp_path / "data.jsonl"
+    with open(json_file, "w") as f:
+        f.write('{"text": "hello"}\n')
+        f.write('{"text": "world"}\n')
+    with patch("data.dataset_loader.AutoTokenizer.from_pretrained", return_value=DummyTokenizer()):
+        ds = load_local_json_dataset(str(json_file), "dummy")
+    assert len(ds) == 2
+    assert "input_ids" in ds.column_names

--- a/tests/test_training_config.py
+++ b/tests/test_training_config.py
@@ -8,3 +8,4 @@ def test_training_config_defaults():
     assert cfg.warmup_steps == 0
     assert cfg.lr_scheduler_type == "linear"
     assert cfg.max_grad_norm == 1.0
+    assert cfg.log_file is None


### PR DESCRIPTION
## Summary
- add streaming and local JSON dataset loading utilities
- allow TrainingConfig to log metrics to a JSON file
- expose `--log-file` argument for training script
- test dataset loader new features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497548ae4083319c85bb4048864753