### PR TITLE
Enhance dataset utilities

### DIFF
--- a/analysis/dataset_analyzer.py
+++ b/analysis/dataset_analyzer.py
@@ -2,18 +2,22 @@ from __future__ import annotations
 
 """Utilities for analyzing tokenized datasets."""
 
-from typing import Optional, Iterable, Dict
+from typing import Optional, Dict, Any
 import argparse
 import json
+from collections import Counter
 
 from datasets import Dataset
-from transformers import AutoTokenizer
 
 from data.dataset_loader import load_and_tokenize
 
 
-def analyze_tokenized_dataset(dataset: Dataset, max_samples: Optional[int] = None) -> Dict[str, float]:
-    """Compute simple statistics for a tokenized dataset.
+def analyze_tokenized_dataset(
+    dataset: Dataset,
+    max_samples: Optional[int] = None,
+    top_k: int = 5,
+) -> Dict[str, Any]:
+    """Compute statistics for a tokenized dataset including length distribution and top tokens.
 
     Parameters
     ----------
@@ -25,20 +29,35 @@ def analyze_tokenized_dataset(dataset: Dataset, max_samples: Optional[int] = Non
     Returns
     -------
     dict
-        Dictionary containing sample count, average token length and
-        vocabulary size.
+        Dictionary containing sample count, average token length, vocabulary size,
+        token length distribution and the most common tokens.
     """
     total_len = 0
     vocab = set()
+    length_counter: Counter[int] = Counter()
+    token_freq: Counter[int] = Counter()
     samples = 0
-    for i, sample in enumerate(dataset):
-        total_len += len(sample["input_ids"])
-        vocab.update(sample["input_ids"])
+
+    for sample in dataset:
+        ids = sample["input_ids"]
+        total_len += len(ids)
+        vocab.update(ids)
+        length_counter[len(ids)] += 1
+        token_freq.update(ids)
         samples += 1
         if max_samples is not None and samples >= max_samples:
             break
+
     avg_len = float(total_len / samples) if samples else 0.0
-    return {"samples": samples, "avg_length": avg_len, "vocab_size": len(vocab)}
+    top_tokens = [tok for tok, _ in token_freq.most_common(top_k)]
+
+    return {
+        "samples": samples,
+        "avg_length": avg_len,
+        "vocab_size": len(vocab),
+        "length_distribution": dict(length_counter),
+        "top_tokens": top_tokens,
+    }
 
 
 def analyze_dataset(
@@ -52,7 +71,8 @@ def analyze_dataset(
     max_length: Optional[int] = None,
     streaming: bool = False,
     max_samples: Optional[int] = None,
-) -> Dict[str, float]:
+    top_k: int = 5,
+) -> Dict[str, Any]:
     """Load and analyze a dataset using ``load_and_tokenize``."""
     ds = load_and_tokenize(
         dataset_name,
@@ -64,7 +84,7 @@ def analyze_dataset(
         max_length=max_length,
         streaming=streaming,
     )
-    return analyze_tokenized_dataset(ds, max_samples=max_samples)
+    return analyze_tokenized_dataset(ds, max_samples=max_samples, top_k=top_k)
 
 
 def main() -> None:
@@ -74,6 +94,7 @@ def main() -> None:
     parser.add_argument("tokenizer_name")
     parser.add_argument("--text-column", default="text")
     parser.add_argument("--max-samples", type=int)
+    parser.add_argument("--top-k", type=int, default=5, help="Number of top tokens to report")
     args = parser.parse_args()
     stats = analyze_dataset(
         args.dataset_name,
@@ -81,6 +102,7 @@ def main() -> None:
         args.tokenizer_name,
         text_column=args.text_column,
         max_samples=args.max_samples,
+        top_k=args.top_k,
     )
     print(json.dumps(stats, indent=2))
 

--- a/tests/test_dataset_analyzer.py
+++ b/tests/test_dataset_analyzer.py
@@ -6,15 +6,18 @@ from analysis.dataset_analyzer import analyze_tokenized_dataset, analyze_dataset
 
 def test_analyze_tokenized_dataset():
     ds = Dataset.from_dict({"input_ids": [[1, 2, 3], [2, 3, 4, 5]]})
-    stats = analyze_tokenized_dataset(ds)
+    stats = analyze_tokenized_dataset(ds, top_k=2)
     assert stats["samples"] == 2
     assert stats["avg_length"] == 3.5
     assert stats["vocab_size"] == 5
+    assert stats["length_distribution"] == {3: 1, 4: 1}
+    assert stats["top_tokens"] == [2, 3]
 
 
 def test_analyze_dataset_patch():
     ds = Dataset.from_dict({"input_ids": [[1, 2], [3, 4, 5]]})
     with patch("analysis.dataset_analyzer.load_and_tokenize", return_value=ds):
-        stats = analyze_dataset("dummy", "train", "dummy")
+        stats = analyze_dataset("dummy", "train", "dummy", top_k=1)
     assert stats["samples"] == 2
     assert stats["vocab_size"] == 5
+    assert stats["top_tokens"] == [3]

--- a/tests/test_dataset_loader.py
+++ b/tests/test_dataset_loader.py
@@ -13,9 +13,12 @@ class DummyTokenizer:
 
 def test_load_and_tokenize_patch():
     dummy_ds = Dataset.from_dict({"text": ["hello", "world"]})
-    with patch("data.dataset_loader.load_dataset", return_value=dummy_ds), \
-         patch("data.dataset_loader.AutoTokenizer.from_pretrained", return_value=DummyTokenizer()):
-        tokenized = load_and_tokenize("dummy", "train", "dummy")
+    with patch("data.dataset_loader.load_dataset", return_value=dummy_ds) as load_mock, \
+         patch("data.dataset_loader.AutoTokenizer.from_pretrained", return_value=DummyTokenizer()), \
+         patch.object(dummy_ds, "shuffle", return_value=dummy_ds) as shuffle_mock:
+        tokenized = load_and_tokenize("dummy", "train", "dummy", shuffle=True, seed=123)
+        shuffle_mock.assert_called_once_with(seed=123)
+        load_mock.assert_called_once()
     assert len(tokenized) == 2
     assert "input_ids" in tokenized.column_names
 


### PR DESCRIPTION
## Summary
- extend dataset analyzer with token distribution and top tokens
- add dataset shuffling options to dataset loader
- adjust tests for new functionality

## Testing
- `python -m py_compile analysis/dataset_analyzer.py data/dataset_loader.py tests/test_dataset_analyzer.py tests/test_dataset_loader.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_6849794333d48331865de66409ef7fa2