### PR TITLE
Improve dataset statistics utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The project follows a simple structure so new functionality can be added easily:
 * `peer_collab/` – collaboration server for shared notes and feedback
 * `security/` – user authentication and ethical flagging
 * `data/` – helpers for loading and tokenizing datasets
+* `analysis/` – dataset statistics utilities
 * `models/` – wrappers around HuggingFace models
 * `train/` – simple training loops
 * `eval/` – evaluation utilities such as perplexity measurement
@@ -65,6 +66,16 @@ ds = load_and_tokenize("ag_news", "train[:100]", "distilgpt2", cache_dir="./cach
 
 New training loops, datasets or evaluation scripts can be added under these
 modules, keeping the code organized as described in `AGENTS.md`.
+
+## Dataset Analysis
+The `analysis` module provides utilities for computing statistics on tokenized
+datasets. `analyze_tokenized_dataset` reports metrics such as average length,
+vocabulary size, lexical diversity and the most frequent token bigrams.
+Run it from the command line:
+
+```bash
+python3 -m analysis.dataset_analyzer ag_news train distilgpt2 --top-k 3
+```
 
 ## License
 This repository is provided for research and experimentation purposes only.

--- a/analysis/dataset_analyzer.py
+++ b/analysis/dataset_analyzer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 """Utilities for analyzing tokenized datasets."""
 
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Tuple
 import argparse
 import json
 from collections import Counter
@@ -36,6 +36,7 @@ def analyze_tokenized_dataset(
     vocab = set()
     length_counter: Counter[int] = Counter()
     token_freq: Counter[int] = Counter()
+    bigram_freq: Counter[Tuple[int, int]] = Counter()
     samples = 0
 
     for sample in dataset:
@@ -44,12 +45,16 @@ def analyze_tokenized_dataset(
         vocab.update(ids)
         length_counter[len(ids)] += 1
         token_freq.update(ids)
+        # Update bigram frequency with consecutive token pairs
+        bigram_freq.update(zip(ids[:-1], ids[1:]))
         samples += 1
         if max_samples is not None and samples >= max_samples:
             break
 
     avg_len = float(total_len / samples) if samples else 0.0
     top_tokens = [tok for tok, _ in token_freq.most_common(top_k)]
+    top_bigrams = [list(bg) for bg, _ in bigram_freq.most_common(top_k)]
+    lexical_diversity = float(len(vocab) / total_len) if total_len else 0.0
 
     return {
         "samples": samples,
@@ -57,6 +62,8 @@ def analyze_tokenized_dataset(
         "vocab_size": len(vocab),
         "length_distribution": dict(length_counter),
         "top_tokens": top_tokens,
+        "top_bigrams": top_bigrams,
+        "lexical_diversity": lexical_diversity,
     }
 
 

--- a/tests/test_dataset_analyzer.py
+++ b/tests/test_dataset_analyzer.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 from datasets import Dataset
+import pytest
 
 from analysis.dataset_analyzer import analyze_tokenized_dataset, analyze_dataset
 
@@ -12,6 +13,8 @@ def test_analyze_tokenized_dataset():
     assert stats["vocab_size"] == 5
     assert stats["length_distribution"] == {3: 1, 4: 1}
     assert stats["top_tokens"] == [2, 3]
+    assert stats["top_bigrams"] == [[2, 3], [1, 2]]
+    assert stats["lexical_diversity"] == pytest.approx(5 / 7)
 
 
 def test_analyze_dataset_patch():
@@ -21,3 +24,5 @@ def test_analyze_dataset_patch():
     assert stats["samples"] == 2
     assert stats["vocab_size"] == 5
     assert stats["top_tokens"] == [3]
+    assert stats["top_bigrams"] == [[1, 2]]
+    assert stats["lexical_diversity"] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- compute bigram frequency and lexical diversity when analyzing tokenized datasets
- update dataset analyzer tests for new metrics
- document dataset analysis module in README

## Testing
- `pytest -q` *(fails: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_68497afbdc0c83318fe0e24344925a8b