### PR TITLE
Add embedding clustering to dataset analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The `analysis` module provides utilities for computing statistics on tokenized
 datasets. `analyze_tokenized_dataset` now reports additional metrics such as
 token entropy and optional trigram frequencies alongside average length,
 vocabulary size and lexical diversity.
+The module also includes `cluster_dataset_embeddings` for grouping dataset
+samples by semantic similarity using transformer embeddings.
 Run it from the command line:
 
 ```bash


### PR DESCRIPTION
## Summary
- extend dataset analyzer with `cluster_dataset_embeddings`
- document new analysis capability
- test clustering with dummy model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498086758c833184027755305c8d97