### PR TITLE
Add t-SNE embedding analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ token entropy and optional trigram frequencies alongside average length,
 vocabulary size and lexical diversity.
 The module also includes `cluster_dataset_embeddings` for grouping dataset
 samples by semantic similarity using transformer embeddings.
+`compute_tsne_embeddings` generates 2D t-SNE coordinates for visualizing
+dataset structure.
 Run it from the command line:
 
 ```bash


### PR DESCRIPTION
## Summary
- add `compute_tsne_embeddings` to generate 2D t-SNE coordinates for datasets
- update README dataset analysis docs
- test new functionality

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684982e8566c83319a583e34fa6c676f