### PR TITLE
Add prompt optimization utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The project follows a simple structure so new functionality can be added easily:
 * `peer_collab/` – collaboration server for shared notes and feedback
 * `security/` – user authentication and ethical flagging
 * `data/` – helpers for loading and tokenizing datasets
-* `analysis/` – dataset statistics utilities
+* `analysis/` – dataset statistics utilities and prompt engineering tools
 * `models/` – wrappers around HuggingFace models
 * `train/` – simple training loops
 * `eval/` – evaluation utilities such as perplexity measurement
@@ -80,10 +80,21 @@ samples by semantic similarity using transformer embeddings.
 `compute_tsne_embeddings` generates 2D t-SNE coordinates for visualizing
 dataset structure.
 Run it from the command line:
-
 ```bash
 python3 -m analysis.dataset_analyzer ag_news train distilgpt2 --top-k 3 --trigrams
 ```
+
+## Prompt Optimization
+The `PromptOptimizer` class generates prompt variations and scores them using perplexity. It returns the best-scoring prompt so you can iteratively refine instructions or dataset prompts.
+
+Example usage:
+```python
+from analysis.prompt_optimizer import PromptOptimizer
+opt = PromptOptimizer("distilgpt2")
+print(opt.optimize_prompt("Summarize the research article:"))
+```
+
+
 
 ## License
 This repository is provided for research and experimentation purposes only.

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -1,1 +1,9 @@
 "Analysis utilities."
+
+from .dataset_analyzer import (
+    analyze_dataset,
+    analyze_tokenized_dataset,
+    cluster_dataset_embeddings,
+    compute_tsne_embeddings,
+)
+from .prompt_optimizer import PromptOptimizer

--- a/analysis/prompt_optimizer.py
+++ b/analysis/prompt_optimizer.py
@@ -1,0 +1,51 @@
+"""Utilities for prompt engineering and optimization."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+class PromptOptimizer:
+    """Generate and score prompt variations to select high quality prompts."""
+
+    def __init__(self, model_name: str, device: Optional[str] = None) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.generator = pipeline(
+            "text-generation",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            device=0 if self.device.type == "cuda" else -1,
+        )
+
+    def generate_variations(self, base_prompt: str, n_variations: int = 5) -> List[str]:
+        """Generate prompt variations from a base prompt."""
+        outputs = self.generator(base_prompt, num_return_sequences=n_variations, max_new_tokens=20)
+        variations = []
+        for out in outputs:
+            text = out["generated_text"]
+            if text.startswith(base_prompt):
+                text = text[len(base_prompt):].strip()
+            if text:
+                variations.append(base_prompt + " " + text)
+            else:
+                variations.append(base_prompt)
+        return variations
+
+    def score_prompt(self, prompt: str) -> float:
+        """Compute perplexity of a prompt as a quality score (lower is better)."""
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            loss = self.model(**inputs, labels=inputs["input_ids"]).loss
+        return float(math.exp(loss.item()))
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        """Return the variation with the lowest perplexity score."""
+        candidates = self.generate_variations(base_prompt, n_variations=n_variations)
+        best_prompt = min(candidates, key=self.score_prompt)
+        return best_prompt

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -1,0 +1,22 @@
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_generate_variations():
+    with patch('analysis.prompt_optimizer.pipeline') as pipe_mock:
+        pipe_mock.return_value = lambda prompt, num_return_sequences, max_new_tokens: [
+            {"generated_text": prompt + " variant 1"},
+            {"generated_text": prompt + " variant 2"},
+        ]
+        opt = PromptOptimizer('distilgpt2')
+        variations = opt.generate_variations('Test prompt', n_variations=2)
+    assert len(variations) == 2
+    assert variations[0].startswith('Test prompt')
+
+
+def test_optimize_prompt():
+    opt = PromptOptimizer('distilgpt2')
+    with patch.object(opt, 'generate_variations', return_value=['a', 'b']), \
+         patch.object(opt, 'score_prompt', side_effect=[2.0, 1.0]):
+        best = opt.optimize_prompt('base')
+    assert best == 'b'


### PR DESCRIPTION
## Summary
- add `PromptOptimizer` for prompt engineering
- include tests for prompt optimizer
- expose new class via analysis package
- document prompt engineering in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68498946c2cc83318c181d7300a84629