### PR TITLE
Add advanced prompt optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ opt = PromptOptimizer("distilgpt2")
 print(opt.optimize_prompt("Summarize the research article:"))
 ```
 
+### Advanced Prompt Optimization
+For more precise control, `AdvancedPromptOptimizer` combines perplexity with
+semantic similarity of sentence embeddings. This helps retain the intent of the
+original prompt while improving clarity.
+
+```python
+from analysis.advanced_prompt_optimizer import AdvancedPromptOptimizer
+adv = AdvancedPromptOptimizer(
+    "distilgpt2", embedding_model="sentence-transformers/paraphrase-MiniLM-L6-v2"
+)
+print(adv.optimize_prompt("Summarize the research article:"))
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -7,3 +7,4 @@ from .dataset_analyzer import (
     compute_tsne_embeddings,
 )
 from .prompt_optimizer import PromptOptimizer
+from .advanced_prompt_optimizer import AdvancedPromptOptimizer

--- a/analysis/advanced_prompt_optimizer.py
+++ b/analysis/advanced_prompt_optimizer.py
@@ -1,0 +1,62 @@
+"""Advanced prompt optimization with semantic similarity."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+import torch
+import torch.nn.functional as F
+from transformers import (
+    AutoModel,
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    pipeline,
+)
+
+from .prompt_optimizer import PromptOptimizer
+
+
+class AdvancedPromptOptimizer(PromptOptimizer):
+    """Optimize prompts using perplexity and semantic similarity."""
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        embedding_model: Optional[str] = None,
+        device: Optional[str] = None,
+        similarity_weight: float = 0.5,
+    ) -> None:
+        super().__init__(model_name, device=device)
+        emb_model_name = embedding_model or model_name
+        self.embed_tokenizer = AutoTokenizer.from_pretrained(emb_model_name)
+        self.embed_model = AutoModel.from_pretrained(emb_model_name).to(self.device)
+        self.similarity_weight = similarity_weight
+
+    def _embedding(self, text: str) -> torch.Tensor:
+        tokens = self.embed_tokenizer(text, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            outputs = self.embed_model(**tokens)
+            hidden = outputs.last_hidden_state
+            mask = tokens["attention_mask"].unsqueeze(-1)
+            pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1)
+        return pooled.squeeze(0)
+
+    def score_prompt(self, prompt: str, *, base_embedding: torch.Tensor) -> float:
+        perplexity = super().score_prompt(prompt)
+        emb = self._embedding(prompt)
+        similarity = F.cosine_similarity(emb, base_embedding, dim=0).item()
+        return perplexity - self.similarity_weight * similarity
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        candidates = self.generate_variations(base_prompt, n_variations=n_variations)
+        base_emb = self._embedding(base_prompt)
+        best_prompt: str = candidates[0]
+        best_score = float("inf")
+        for cand in candidates:
+            score = self.score_prompt(cand, base_embedding=base_emb)
+            if score < best_score:
+                best_score = score
+                best_prompt = cand
+        return best_prompt

--- a/tests/test_advanced_prompt_optimizer.py
+++ b/tests/test_advanced_prompt_optimizer.py
@@ -1,0 +1,13 @@
+import torch
+from analysis.advanced_prompt_optimizer import AdvancedPromptOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_advanced_optimize_prompt():
+    adv = AdvancedPromptOptimizer("distilgpt2", similarity_weight=1.0)
+    with patch.object(adv, "generate_variations", return_value=["a", "b"]), \
+         patch.object(PromptOptimizer, "score_prompt", side_effect=[2.0, 1.0]), \
+         patch.object(adv, "_embedding", side_effect=[torch.tensor([0.0]), torch.tensor([0.2]), torch.tensor([0.4])]):
+        best = adv.optimize_prompt("base")
+    assert best == "b"


### PR DESCRIPTION
## Summary
- extend analysis utilities with `AdvancedPromptOptimizer`
- export the new optimizer
- document advanced prompt optimization in README
- test advanced optimizer

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for torch, datasets, numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68498bb5bf688331b135cc7ff67d2f70