### PR TITLE
Add prompt augmentation utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ adv = AdvancedPromptOptimizer(
 print(adv.optimize_prompt("Summarize the research article:"))
 ```
 
+### Prompt Augmentation
+
+`PromptAugmenter` generates additional prompt variations to expand training datasets.
+
+```python
+from analysis.prompt_augmenter import PromptAugmenter
+aug = PromptAugmenter("distilgpt2")
+prompts = aug.augment_dataset(["Write an abstract about AI"], n_variations=2)
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -8,3 +8,4 @@ from .dataset_analyzer import (
 )
 from .prompt_optimizer import PromptOptimizer
 from .advanced_prompt_optimizer import AdvancedPromptOptimizer
+from .prompt_augmenter import PromptAugmenter

--- a/analysis/prompt_augmenter.py
+++ b/analysis/prompt_augmenter.py
@@ -1,0 +1,43 @@
+"""Prompt augmentation utilities."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+class PromptAugmenter:
+    """Generate additional prompt variations for training."""
+
+    def __init__(self, model_name: str, device: Optional[str] = None) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.generator = pipeline(
+            "text-generation",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            device=0 if self.device.type == "cuda" else -1,
+        )
+
+    def augment_prompt(self, prompt: str, n_variations: int = 3) -> List[str]:
+        """Return multiple variations of a single prompt."""
+        outputs = self.generator(prompt, num_return_sequences=n_variations, max_new_tokens=30)
+        variations = []
+        for out in outputs:
+            text = out["generated_text"]
+            if text.startswith(prompt):
+                text = text[len(prompt):].strip()
+            new_prompt = f"{prompt} {text}".strip()
+            variations.append(new_prompt)
+        return variations
+
+    def augment_dataset(self, prompts: List[str], n_variations: int = 3) -> List[str]:
+        """Augment a list of prompts with generated variations."""
+        augmented: List[str] = []
+        for p in prompts:
+            augmented.append(p)
+            augmented.extend(self.augment_prompt(p, n_variations=n_variations))
+        return augmented

--- a/tests/test_prompt_augmenter.py
+++ b/tests/test_prompt_augmenter.py
@@ -1,0 +1,21 @@
+import pytest
+from analysis.prompt_augmenter import PromptAugmenter
+from unittest.mock import patch
+
+
+def test_augment_prompt():
+    aug = PromptAugmenter("distilgpt2")
+    with patch.object(aug, "generator") as gen_mock:
+        gen_mock.return_value = [
+            {"generated_text": "base variation1"},
+            {"generated_text": "base variation2"},
+        ]
+        variations = aug.augment_prompt("base", n_variations=2)
+    assert variations == ["base variation1", "base variation2"]
+
+
+def test_augment_dataset():
+    aug = PromptAugmenter("distilgpt2")
+    with patch.object(aug, "augment_prompt", side_effect=[["p1 v1", "p1 v2"], ["p2 v1", "p2 v2"]]):
+        prompts = aug.augment_dataset(["p1", "p2"], n_variations=2)
+    assert prompts == ["p1", "p1 v1", "p1 v2", "p2", "p2 v1", "p2 v2"]


### PR DESCRIPTION
## Summary
- expand prompt engineering tools with `PromptAugmenter`
- expose the augmenter in `analysis` package
- document prompt augmentation usage
- test prompt augmenter module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68498e2667fc8331b50c125dac9cccab