### PR TITLE
Add evolutionary prompt optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ aug = PromptAugmenter("distilgpt2")
 prompts = aug.augment_dataset(["Write an abstract about AI"], n_variations=2)
 ```
 
+### Evolutionary Prompt Engineering
+
+`PromptEvolver` applies a simple genetic algorithm to refine prompts over several generations.
+
+```python
+from analysis.prompt_evolver import PromptEvolver
+pe = PromptEvolver("distilgpt2")
+print(pe.evolve_prompt("Describe the benefits of renewable energy"))
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -9,3 +9,4 @@ from .dataset_analyzer import (
 from .prompt_optimizer import PromptOptimizer
 from .advanced_prompt_optimizer import AdvancedPromptOptimizer
 from .prompt_augmenter import PromptAugmenter
+from .prompt_evolver import PromptEvolver

--- a/analysis/prompt_evolver.py
+++ b/analysis/prompt_evolver.py
@@ -1,0 +1,77 @@
+"""Evolutionary prompt optimization utilities."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import List, Optional
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
+
+class PromptEvolver:
+    """Evolve prompts using a simple genetic algorithm."""
+
+    def __init__(self, model_name: str, device: Optional[str] = None) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.generator = pipeline(
+            "text-generation",
+            model=self.model,
+            tokenizer=self.tokenizer,
+            device=0 if self.device.type == "cuda" else -1,
+        )
+
+    def _mutate(self, prompt: str) -> str:
+        """Return a mutated prompt using the language model."""
+        out = self.generator(prompt, num_return_sequences=1, max_new_tokens=10)[0]
+        gen = out["generated_text"]
+        if gen.startswith(prompt):
+            gen = gen[len(prompt):].strip()
+        return f"{prompt} {gen}".strip()
+
+    def _score(self, prompt: str) -> float:
+        """Compute perplexity of a prompt."""
+        inputs = self.tokenizer(prompt, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            loss = self.model(**inputs, labels=inputs["input_ids"]).loss
+        return float(math.exp(loss.item()))
+
+    def evolve_prompt(
+        self,
+        base_prompt: str,
+        *,
+        generations: int = 3,
+        population_size: int = 6,
+        retain: float = 0.5,
+        mutation_rate: float = 0.3,
+    ) -> str:
+        """Iteratively evolve a prompt and return the best result."""
+        population = [base_prompt] + [self._mutate(base_prompt) for _ in range(population_size - 1)]
+        for _ in range(generations):
+            scored = [(p, self._score(p)) for p in population]
+            scored.sort(key=lambda x: x[1])  # lower perplexity is better
+            retain_len = max(1, int(len(scored) * retain))
+            parents = [p for p, _ in scored[:retain_len]]
+            # Crossover
+            children: List[str] = []
+            while len(children) + len(parents) < population_size:
+                a, b = random.sample(parents, 2)
+                split_a = a.split()
+                split_b = b.split()
+                if not split_a or not split_b:
+                    child = a if self._score(a) <= self._score(b) else b
+                else:
+                    cut_a = random.randint(1, len(split_a))
+                    cut_b = random.randint(1, len(split_b))
+                    child = " ".join(split_a[:cut_a] + split_b[cut_b:])
+                children.append(child)
+            population = parents + children
+            # Mutation
+            for i in range(len(population)):
+                if random.random() < mutation_rate:
+                    population[i] = self._mutate(population[i])
+        best_prompt = min(population, key=self._score)
+        return best_prompt

--- a/tests/test_prompt_evolver.py
+++ b/tests/test_prompt_evolver.py
@@ -1,0 +1,10 @@
+from analysis.prompt_evolver import PromptEvolver
+from unittest.mock import patch
+
+
+def test_evolve_prompt():
+    evolver = PromptEvolver("distilgpt2")
+    with patch.object(evolver, "_mutate", side_effect=["a", "b", "c", "d"] * 3), \
+         patch.object(evolver, "_score", side_effect=[1.0, 0.5, 0.2, 0.3] * 3):
+        best = evolver.evolve_prompt("base", generations=2, population_size=4)
+    assert isinstance(best, str)


### PR DESCRIPTION
## Summary
- add `PromptEvolver` to explore genetic prompt refinement
- expose `PromptEvolver` in `analysis.__init__`
- document evolutionary prompt engineering in README
- test new evolutionary optimizer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684993c84348833199b0f70c0b0a06c6