### PR TITLE
Add bandit prompt optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ pe = PromptEvolver("distilgpt2")
 print(pe.evolve_prompt("Describe the benefits of renewable energy"))
 ```
 
+### Bandit-Based Prompt Optimization
+
+`PromptBanditOptimizer` employs an epsilon-greedy multi-armed bandit strategy
+to iteratively explore and exploit prompt variations based on a custom reward
+function.
+
+```python
+from analysis.prompt_bandit_optimizer import PromptBanditOptimizer
+
+# Reward function prefers longer prompts
+bandit = PromptBanditOptimizer("distilgpt2", reward_fn=len, epsilon=0.1)
+best = bandit.optimize_prompt("Write a summary")
+print(best)
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -10,3 +10,4 @@ from .prompt_optimizer import PromptOptimizer
 from .advanced_prompt_optimizer import AdvancedPromptOptimizer
 from .prompt_augmenter import PromptAugmenter
 from .prompt_evolver import PromptEvolver
+from .prompt_bandit_optimizer import PromptBanditOptimizer

--- a/analysis/prompt_bandit_optimizer.py
+++ b/analysis/prompt_bandit_optimizer.py
@@ -1,0 +1,45 @@
+"""Prompt optimization using a multi-armed bandit approach."""
+
+from __future__ import annotations
+
+import random
+from typing import Callable, Optional
+
+from .prompt_optimizer import PromptOptimizer
+
+
+class PromptBanditOptimizer(PromptOptimizer):
+    """Optimize prompts via epsilon-greedy multi-armed bandit."""
+
+    def __init__(
+        self,
+        model_name: str,
+        reward_fn: Callable[[str], float],
+        *,
+        epsilon: float = 0.1,
+        iterations: int = 10,
+        device: Optional[str] = None,
+    ) -> None:
+        super().__init__(model_name, device=device)
+        self.reward_fn = reward_fn
+        self.epsilon = epsilon
+        self.iterations = iterations
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        """Return the prompt with the highest estimated reward."""
+        candidates = self.generate_variations(base_prompt, n_variations=n_variations)
+        counts = [0 for _ in candidates]
+        values = [0.0 for _ in candidates]
+
+        for _ in range(self.iterations):
+            if random.random() < self.epsilon:
+                idx = random.randrange(len(candidates))
+            else:
+                idx = max(range(len(candidates)), key=lambda i: values[i])
+            reward = self.reward_fn(candidates[idx])
+            counts[idx] += 1
+            # Incremental mean update
+            values[idx] += (reward - values[idx]) / counts[idx]
+
+        best_idx = max(range(len(candidates)), key=lambda i: values[i])
+        return candidates[best_idx]

--- a/tests/test_prompt_bandit_optimizer.py
+++ b/tests/test_prompt_bandit_optimizer.py
@@ -1,0 +1,12 @@
+from analysis.prompt_bandit_optimizer import PromptBanditOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_bandit_optimize_prompt():
+    # Reward is simply the prompt length
+    bandit = PromptBanditOptimizer("distilgpt2", reward_fn=len, epsilon=0.0, iterations=3)
+    with patch.object(bandit, "generate_variations", return_value=["a", "abcd"]), \
+         patch.object(PromptOptimizer, "score_prompt", return_value=0.0):
+        best = bandit.optimize_prompt("base", n_variations=2)
+    assert best == "abcd"


### PR DESCRIPTION
## Summary
- implement `PromptBanditOptimizer` using an epsilon-greedy multi-armed bandit
- expose the new optimizer from `analysis/__init__.py`
- document how to use bandit-based prompt optimization in `README`
- test the bandit optimizer logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684995a7c19083319f47242fba8b7947