### PR TITLE
Add simulated annealing prompt optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,20 @@ best = bandit.optimize_prompt("Write a summary")
 print(best)
 ```
 
+### Simulated Annealing Prompt Optimization
+
+`PromptAnnealingOptimizer` explores prompt variations using a simulated annealing strategy. It
+accepts or rejects new prompts based on a temperature schedule, allowing occasional
+worse prompts early on to escape local minima.
+
+```python
+from analysis.prompt_annealing_optimizer import PromptAnnealingOptimizer
+
+annealer = PromptAnnealingOptimizer("distilgpt2", temperature=1.0, cooling=0.8, steps=5)
+best = annealer.optimize_prompt("Write a summary")
+print(best)
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -11,3 +11,4 @@ from .advanced_prompt_optimizer import AdvancedPromptOptimizer
 from .prompt_augmenter import PromptAugmenter
 from .prompt_evolver import PromptEvolver
 from .prompt_bandit_optimizer import PromptBanditOptimizer
+from .prompt_annealing_optimizer import PromptAnnealingOptimizer

--- a/analysis/prompt_annealing_optimizer.py
+++ b/analysis/prompt_annealing_optimizer.py
@@ -1,0 +1,54 @@
+"""Prompt optimization using simulated annealing."""
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Callable, Optional
+
+from .prompt_optimizer import PromptOptimizer
+
+
+class PromptAnnealingOptimizer(PromptOptimizer):
+    """Optimize prompts via simulated annealing."""
+
+    def __init__(
+        self,
+        model_name: str,
+        reward_fn: Optional[Callable[[str], float]] = None,
+        *,
+        temperature: float = 1.0,
+        cooling: float = 0.95,
+        steps: int = 50,
+        device: Optional[str] = None,
+    ) -> None:
+        super().__init__(model_name, device=device)
+        self.reward_fn = reward_fn
+        self.temperature = temperature
+        self.cooling = cooling
+        self.steps = steps
+
+    def _score(self, prompt: str) -> float:
+        if self.reward_fn is not None:
+            return self.reward_fn(prompt)
+        return super().score_prompt(prompt)
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        current = base_prompt
+        best = current
+        current_score = self._score(current)
+        best_score = current_score
+        temp = self.temperature
+        for _ in range(self.steps):
+            candidate = self.generate_variations(current, n_variations=1)[0]
+            cand_score = self._score(candidate)
+            if cand_score < best_score:
+                best, best_score = candidate, cand_score
+            if cand_score < current_score:
+                accept_prob = 1.0
+            else:
+                accept_prob = math.exp((current_score - cand_score) / max(temp, 1e-8))
+            if random.random() < accept_prob:
+                current, current_score = candidate, cand_score
+            temp *= self.cooling
+        return best

--- a/tests/test_prompt_annealing_optimizer.py
+++ b/tests/test_prompt_annealing_optimizer.py
@@ -1,0 +1,12 @@
+from analysis.prompt_annealing_optimizer import PromptAnnealingOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_annealing_optimize_prompt():
+    annealer = PromptAnnealingOptimizer("distilgpt2", temperature=1.0, cooling=0.5, steps=3)
+    with patch.object(annealer, "generate_variations", side_effect=[["a"], ["b"], ["c"]]), \
+         patch.object(PromptAnnealingOptimizer, "_score", side_effect=[3.0, 2.0, 1.5, 1.0]), \
+         patch("analysis.prompt_annealing_optimizer.random.random", return_value=0.0):
+        best = annealer.optimize_prompt("base", n_variations=1)
+    assert best == "c"


### PR DESCRIPTION
## Summary
- add `PromptAnnealingOptimizer` using simulated annealing for prompt engineering
- expose new optimizer from analysis package
- document annealing optimizer in README
- test optimizer logic

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6849975c83088331a7ff90209be1f1df