### PR TITLE
Add RL-based prompt optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ best = annealer.optimize_prompt("Write a summary")
 print(best)
 ```
 
+### Reinforcement Learning Prompt Optimization
+
+`PromptRLOptimizer` applies a simple Q-learning strategy to refine prompts
+based on a custom reward function. It explores variations of the base prompt
+over multiple episodes and learns which prompts yield the highest reward.
+
+```python
+from analysis.prompt_rl_optimizer import PromptRLOptimizer
+
+# Reward prefers longer prompts
+rl = PromptRLOptimizer("distilgpt2", reward_fn=len, episodes=5, epsilon=0.1)
+best = rl.optimize_prompt("Write a summary")
+print(best)
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -12,3 +12,4 @@ from .prompt_augmenter import PromptAugmenter
 from .prompt_evolver import PromptEvolver
 from .prompt_bandit_optimizer import PromptBanditOptimizer
 from .prompt_annealing_optimizer import PromptAnnealingOptimizer
+from .prompt_rl_optimizer import PromptRLOptimizer

--- a/analysis/prompt_bandit_optimizer.py
+++ b/analysis/prompt_bandit_optimizer.py
@@ -31,6 +31,12 @@ class PromptBanditOptimizer(PromptOptimizer):
         counts = [0 for _ in candidates]
         values = [0.0 for _ in candidates]
 
+        # Initialize estimates with one sample of each arm
+        for i, cand in enumerate(candidates):
+            reward = self.reward_fn(cand)
+            counts[i] = 1
+            values[i] = reward
+
         for _ in range(self.iterations):
             if random.random() < self.epsilon:
                 idx = random.randrange(len(candidates))

--- a/analysis/prompt_rl_optimizer.py
+++ b/analysis/prompt_rl_optimizer.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+"""Reinforcement learning based prompt optimizer."""
+
+import random
+from typing import Callable, Dict, Optional
+
+from .prompt_optimizer import PromptOptimizer
+
+
+class PromptRLOptimizer(PromptOptimizer):
+    """Refine prompts using a simple Q-learning algorithm."""
+
+    def __init__(
+        self,
+        model_name: str,
+        reward_fn: Callable[[str], float] | None = None,
+        *,
+        episodes: int = 10,
+        epsilon: float = 0.2,
+        lr: float = 0.3,
+        device: Optional[str] = None,
+    ) -> None:
+        super().__init__(model_name, device=device)
+        self.reward_fn = reward_fn
+        self.episodes = episodes
+        self.epsilon = epsilon
+        self.lr = lr
+        self._q_values: Dict[str, float] = {}
+
+    def _reward(self, prompt: str) -> float:
+        if self.reward_fn is not None:
+            return self.reward_fn(prompt)
+        return -self.score_prompt(prompt)
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        candidates = self.generate_variations(base_prompt, n_variations=n_variations)
+        for c in candidates:
+            if c not in self._q_values:
+                self._q_values[c] = self._reward(c)
+
+        for _ in range(self.episodes):
+            if random.random() < self.epsilon:
+                prompt = random.choice(candidates)
+            else:
+                prompt = max(candidates, key=lambda p: self._q_values.get(p, 0.0))
+            reward = self._reward(prompt)
+            self._q_values[prompt] = self._q_values.get(prompt, 0.0) + self.lr * (
+                reward - self._q_values.get(prompt, 0.0)
+            )
+        best_prompt = max(self._q_values, key=self._q_values.get)
+        return best_prompt

--- a/tests/test_prompt_rl_optimizer.py
+++ b/tests/test_prompt_rl_optimizer.py
@@ -1,0 +1,12 @@
+from analysis.prompt_rl_optimizer import PromptRLOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_rl_optimize_prompt():
+    # reward uses length of prompt
+    rl = PromptRLOptimizer("distilgpt2", reward_fn=len, episodes=2, epsilon=0.0, lr=1.0)
+    with patch.object(rl, "generate_variations", side_effect=[["a", "bb"], ["bb"]]), \
+         patch.object(PromptOptimizer, "score_prompt", return_value=0.0):
+        best = rl.optimize_prompt("base", n_variations=2)
+    assert best == "bb"


### PR DESCRIPTION
## Summary
- add reinforcement learning style optimizer for prompts
- update bandit optimizer to initialize with a sample of each prompt
- document RL optimizer in README
- include tests for new optimizer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849990d7fbc83319bb62867a189c5c7