### PR TITLE
Add Bayesian prompt optimization

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -13,3 +13,4 @@ from .prompt_evolver import PromptEvolver
 from .prompt_bandit_optimizer import PromptBanditOptimizer
 from .prompt_annealing_optimizer import PromptAnnealingOptimizer
 from .prompt_rl_optimizer import PromptRLOptimizer
+from .prompt_bayes_optimizer import BayesianPromptOptimizer

--- a/analysis/prompt_bayes_optimizer.py
+++ b/analysis/prompt_bayes_optimizer.py
@@ -1,0 +1,49 @@
+"""Prompt optimization using Bayesian optimization."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple, List
+
+from skopt import gp_minimize
+from skopt.space import Real
+
+from .prompt_optimizer import PromptOptimizer
+
+
+class BayesianPromptOptimizer(PromptOptimizer):
+    """Optimize prompts by tuning generation temperature via Bayesian search."""
+
+    def __init__(
+        self,
+        model_name: str,
+        *,
+        iterations: int = 10,
+        temp_range: Tuple[float, float] = (0.5, 1.5),
+        device: Optional[str] = None,
+    ) -> None:
+        super().__init__(model_name, device=device)
+        self.iterations = iterations
+        self.temp_range = temp_range
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        """Return the best prompt found via Bayesian optimization."""
+
+        history: List[Tuple[str, float]] = []
+
+        def objective(params: List[float]) -> float:
+            temp = params[0]
+            cand = self.generate_variations(
+                base_prompt, n_variations=1, temperature=temp
+            )[0]
+            score = self.score_prompt(cand)
+            history.append((cand, score))
+            return score
+
+        gp_minimize(
+            objective,
+            [Real(self.temp_range[0], self.temp_range[1])],
+            n_calls=self.iterations,
+            random_state=42,
+        )
+        best_prompt, _ = min(history, key=lambda x: x[1])
+        return best_prompt

--- a/analysis/prompt_optimizer.py
+++ b/analysis/prompt_optimizer.py
@@ -23,9 +23,27 @@ class PromptOptimizer:
             device=0 if self.device.type == "cuda" else -1,
         )
 
-    def generate_variations(self, base_prompt: str, n_variations: int = 5) -> List[str]:
-        """Generate prompt variations from a base prompt."""
-        outputs = self.generator(base_prompt, num_return_sequences=n_variations, max_new_tokens=20)
+    def generate_variations(
+        self, base_prompt: str, n_variations: int = 5, *, temperature: float = 1.0
+    ) -> List[str]:
+        """Generate prompt variations from a base prompt.
+
+        Parameters
+        ----------
+        base_prompt:
+            Prompt used as the starting point for generation.
+        n_variations:
+            Number of variations to produce.
+        temperature:
+            Sampling temperature controlling randomness of generations.
+        """
+        outputs = self.generator(
+            base_prompt,
+            num_return_sequences=n_variations,
+            max_new_tokens=20,
+            do_sample=True,
+            temperature=temperature,
+        )
         variations = []
         for out in outputs:
             text = out["generated_text"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ requests
 matplotlib
 datasets
 pytest
+scikit-optimize

--- a/tests/test_prompt_bayes_optimizer.py
+++ b/tests/test_prompt_bayes_optimizer.py
@@ -1,0 +1,16 @@
+from analysis.prompt_bayes_optimizer import BayesianPromptOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_bayesian_optimize_prompt():
+    opt = BayesianPromptOptimizer("distilgpt2", iterations=2)
+    with patch.object(opt, "generate_variations", side_effect=[["a"], ["b"]]), \
+         patch.object(PromptOptimizer, "score_prompt", side_effect=[2.0, 1.0]), \
+         patch("analysis.prompt_bayes_optimizer.gp_minimize") as gp_mock:
+        def runner(func, space, n_calls, random_state=None):
+            for _ in range(n_calls):
+                func([1.0])
+        gp_mock.side_effect = runner
+        best = opt.optimize_prompt("base", n_variations=1)
+    assert best == "b"

--- a/tests/test_prompt_optimizer.py
+++ b/tests/test_prompt_optimizer.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 
 def test_generate_variations():
     with patch('analysis.prompt_optimizer.pipeline') as pipe_mock:
-        pipe_mock.return_value = lambda prompt, num_return_sequences, max_new_tokens: [
+        pipe_mock.return_value = (
+            lambda prompt, num_return_sequences, max_new_tokens, do_sample=True, temperature=1.0: [
             {"generated_text": prompt + " variant 1"},
             {"generated_text": prompt + " variant 2"},
-        ]
+            ]
+        )
         opt = PromptOptimizer('distilgpt2')
         variations = opt.generate_variations('Test prompt', n_variations=2)
     assert len(variations) == 2


### PR DESCRIPTION
## Summary
- extend `PromptOptimizer.generate_variations` with a temperature parameter
- add new `BayesianPromptOptimizer` using scikit-optimize
- update analysis `__init__` and tests
- add `scikit-optimize` to requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499b4d71808331a3b3c32af5de34b5