### PR TITLE
Add meta prompt optimizer for advanced prompt engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,20 @@ best = rl.optimize_prompt("Write a summary")
 print(best)
 ```
 
+### Meta Prompt Optimization
+
+`MetaPromptOptimizer` chains multiple optimizers (bandit, annealing, and
+reinforcement learning) to search a broader space of prompt variations and
+select the overall best prompt.
+
+```python
+from analysis.meta_prompt_optimizer import MetaPromptOptimizer
+
+meta = MetaPromptOptimizer("distilgpt2")
+best = meta.optimize_prompt("Write a summary")
+print(best)
+```
+
 
 
 ## License

--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -14,3 +14,4 @@ from .prompt_bandit_optimizer import PromptBanditOptimizer
 from .prompt_annealing_optimizer import PromptAnnealingOptimizer
 from .prompt_rl_optimizer import PromptRLOptimizer
 from .prompt_bayes_optimizer import BayesianPromptOptimizer
+from .meta_prompt_optimizer import MetaPromptOptimizer

--- a/analysis/meta_prompt_optimizer.py
+++ b/analysis/meta_prompt_optimizer.py
@@ -1,0 +1,42 @@
+"""Combine multiple prompt optimizers for enhanced results."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from .prompt_optimizer import PromptOptimizer
+from .prompt_bandit_optimizer import PromptBanditOptimizer
+from .prompt_annealing_optimizer import PromptAnnealingOptimizer
+from .prompt_rl_optimizer import PromptRLOptimizer
+
+
+class MetaPromptOptimizer(PromptOptimizer):
+    """Run several optimizers sequentially and return the best prompt."""
+
+    def __init__(self, model_name: str, *, device: Optional[str] = None) -> None:
+        super().__init__(model_name, device=device)
+        # Use internal score_prompt as reward for bandit and RL optimizers
+        self.bandit = PromptBanditOptimizer(
+            model_name,
+            reward_fn=lambda p: -self.score_prompt(p),
+            device=device,
+            iterations=3,
+            epsilon=0.2,
+        )
+        self.annealer = PromptAnnealingOptimizer(model_name, device=device)
+        self.rl = PromptRLOptimizer(
+            model_name,
+            reward_fn=lambda p: -self.score_prompt(p),
+            device=device,
+            episodes=3,
+            epsilon=0.1,
+        )
+
+    def optimize_prompt(self, base_prompt: str, n_variations: int = 5) -> str:
+        """Apply each optimizer and choose the overall best prompt."""
+        prompt1 = self.bandit.optimize_prompt(base_prompt, n_variations=n_variations)
+        prompt2 = self.annealer.optimize_prompt(prompt1, n_variations=n_variations)
+        prompt3 = self.rl.optimize_prompt(prompt2, n_variations=n_variations)
+        candidates = [base_prompt, prompt1, prompt2, prompt3]
+        best_prompt = min(candidates, key=self.score_prompt)
+        return best_prompt

--- a/tests/test_meta_prompt_optimizer.py
+++ b/tests/test_meta_prompt_optimizer.py
@@ -1,0 +1,13 @@
+from analysis.meta_prompt_optimizer import MetaPromptOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_meta_optimize_prompt():
+    meta = MetaPromptOptimizer("distilgpt2")
+    with patch.object(meta.bandit, "optimize_prompt", return_value="p1"), \
+         patch.object(meta.annealer, "optimize_prompt", return_value="p2"), \
+         patch.object(meta.rl, "optimize_prompt", return_value="p3"), \
+         patch.object(PromptOptimizer, "score_prompt", side_effect=[3.0, 2.0, 4.0, 1.0]):
+        best = meta.optimize_prompt("base")
+    assert best == "p3"


### PR DESCRIPTION
## Summary
- implement `MetaPromptOptimizer` to combine bandit, annealing and RL optimizers
- expose new optimizer in analysis module
- document usage in README
- add unit test for new optimizer

## Testing
- `pip install -q torch numpy datasets`
- `pip install -q scikit-learn transformers scikit-optimize`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499dd7ba308331b777372763ad360e