### PR TITLE
Enhance training utilities with experiment tracker

### DIFF
--- a/tests/test_augment_text_dataset.py
+++ b/tests/test_augment_text_dataset.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+from datasets import Dataset
+
+from data.dataset_loader import augment_text_dataset
+
+
+class DummyAugmenter:
+    def augment_prompt(self, prompt, n_variations=1):
+        return [f"{prompt} v{i}" for i in range(n_variations)]
+
+
+def test_augment_text_dataset():
+    ds = Dataset.from_dict({"text": ["a", "b"]})
+    with patch("data.dataset_loader.PromptAugmenter", return_value=DummyAugmenter()):
+        aug = augment_text_dataset(ds, "dummy", n_variations=2)
+    assert len(aug) == 6  # original + 2 variations each
+    texts = set(aug["text"])
+    assert "a v0" in texts and "b v1" in texts

--- a/tests/test_experiment_tracker.py
+++ b/tests/test_experiment_tracker.py
@@ -1,0 +1,12 @@
+from train.experiment_tracker import ExperimentTracker
+
+
+def test_experiment_tracker(tmp_path):
+    tracker = ExperimentTracker()
+    tracker.log(step=1, loss=0.5)
+    tracker.log(step=2, loss=0.4)
+    out_file = tmp_path / "log.json"
+    tracker.save(out_file)
+    data = out_file.read_text()
+    assert "loss" in data
+    assert "step" in data

--- a/train/experiment_tracker.py
+++ b/train/experiment_tracker.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+"""Experiment tracking utilities."""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+import json
+
+
+@dataclass
+class ExperimentTracker:
+    """Log training metrics and save them to disk."""
+
+    history: List[Dict[str, Any]] = field(default_factory=list)
+
+    def log(self, **metrics: Any) -> None:
+        self.history.append(metrics)
+
+    def save(self, path: str) -> None:
+        with open(path, "w") as f:
+            json.dump(self.history, f, indent=2)
+
+
+class TrackerCallback:
+    """HuggingFace Trainer callback that records logs to an ExperimentTracker."""
+
+    def __init__(self, tracker: ExperimentTracker) -> None:
+        self.tracker = tracker
+
+    def on_log(self, args, state, control, logs=None, **kwargs):  # type: ignore[override]
+        if logs:
+            entry = {"step": state.global_step}
+            entry.update(logs)
+            self.tracker.log(**entry)


### PR DESCRIPTION
## Summary
- add `ExperimentTracker` and integrate via `TrackerCallback`
- extend training loop to log metrics
- provide dataset augmentation via `augment_text_dataset`
- add unit tests for new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a117d5db08331b4f896f123fafa26