### PR TITLE
Add soft prompt embedding tuner

### DIFF
--- a/analysis/__init__.py
+++ b/analysis/__init__.py
@@ -15,3 +15,4 @@ from .prompt_annealing_optimizer import PromptAnnealingOptimizer
 from .prompt_rl_optimizer import PromptRLOptimizer
 from .prompt_bayes_optimizer import BayesianPromptOptimizer
 from .meta_prompt_optimizer import MetaPromptOptimizer
+from .prompt_embedding_tuner import PromptEmbeddingTuner

--- a/analysis/prompt_embedding_tuner.py
+++ b/analysis/prompt_embedding_tuner.py
@@ -1,0 +1,52 @@
+"""Trainable soft prompt embeddings for prompt engineering."""
+
+from __future__ import annotations
+
+from typing import Optional, List
+
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class PromptEmbeddingTuner:
+    """Tune soft prompt embeddings to minimize language model loss."""
+
+    def __init__(self, model_name: str, prompt_length: int, *, device: Optional[str] = None) -> None:
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self.model = AutoModelForCausalLM.from_pretrained(model_name).to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.prompt_length = prompt_length
+        emb_dim = self.model.get_input_embeddings().weight.shape[1]
+        self.prompt_embeddings = torch.nn.Parameter(
+            torch.randn(prompt_length, emb_dim, device=self.device)
+        )
+        self.optimizer = torch.optim.Adam([self.prompt_embeddings], lr=1e-2)
+
+    def tune(self, target_text: str, *, steps: int = 20) -> None:
+        """Optimize the prompt embeddings for the given target text."""
+        inputs = self.tokenizer(target_text, return_tensors="pt").to(self.device)
+        input_embeds = self.model.get_input_embeddings()(inputs["input_ids"])
+        labels_prefix = torch.full(
+            (inputs["input_ids"].size(0), self.prompt_length),
+            -100,
+            dtype=torch.long,
+            device=self.device,
+        )
+        labels = torch.cat([labels_prefix, inputs["input_ids"]], dim=1)
+        prompt_batch = self.prompt_embeddings.unsqueeze(0).expand(
+            inputs["input_ids"].size(0), -1, -1
+        )
+        for _ in range(steps):
+            self.optimizer.zero_grad()
+            embeds = torch.cat([prompt_batch, input_embeds], dim=1)
+            outputs = self.model(inputs_embeds=embeds, labels=labels)
+            loss = outputs.loss
+            loss.backward()
+            self.optimizer.step()
+
+    def get_prompt_tokens(self) -> List[str]:
+        """Return tokens approximating the soft prompt embeddings."""
+        embedding_matrix = self.model.get_input_embeddings().weight
+        sims = torch.matmul(self.prompt_embeddings, embedding_matrix.t())
+        ids = torch.argmax(sims, dim=1)
+        return [self.tokenizer.decode([i]) for i in ids]

--- a/tests/test_prompt_embedding_tuner.py
+++ b/tests/test_prompt_embedding_tuner.py
@@ -1,0 +1,50 @@
+import torch
+from analysis.prompt_embedding_tuner import PromptEmbeddingTuner
+from unittest.mock import patch
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.embed = torch.nn.Embedding(10, 4)
+        self.lm_head = torch.nn.Linear(4, 10)
+
+    def forward(self, input_ids=None, inputs_embeds=None, labels=None):
+        if inputs_embeds is None:
+            inputs_embeds = self.embed(input_ids)
+        logits = self.lm_head(inputs_embeds)
+        loss = logits.mean()
+        return type('Output', (), {'loss': loss, 'logits': logits})
+
+    def get_input_embeddings(self):
+        return self.embed
+
+    def to(self, device):
+        return self
+
+
+class DummyBatch(dict):
+    def to(self, device):
+        return self
+
+
+class DummyTokenizer:
+    def __call__(self, text, return_tensors=None):
+        ids = torch.tensor([[1, 2]])
+        if return_tensors == 'pt':
+            return DummyBatch({'input_ids': ids, 'attention_mask': torch.ones_like(ids)})
+        return ids.tolist()
+
+    def decode(self, ids):
+        return ' '.join(str(i) for i in ids)
+
+
+def test_prompt_embedding_tuner():
+    with patch('analysis.prompt_embedding_tuner.AutoModelForCausalLM.from_pretrained', return_value=DummyModel()), \
+         patch('analysis.prompt_embedding_tuner.AutoTokenizer.from_pretrained', return_value=DummyTokenizer()):
+        tuner = PromptEmbeddingTuner('dummy', prompt_length=2, device='cpu')
+        initial = tuner.prompt_embeddings.clone()
+        tuner.tune('hello', steps=1)
+        assert not torch.allclose(initial, tuner.prompt_embeddings)
+        tokens = tuner.get_prompt_tokens()
+        assert len(tokens) == 2


### PR DESCRIPTION
## Summary
- add `PromptEmbeddingTuner` for training soft prompt embeddings
- expose `PromptEmbeddingTuner` in `analysis.__init__`
- test new tuner with dummy model and tokenizer

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a322b11e083318a4e651750054f6a