### PR TITLE
Add contextual prompt optimizer and training callback

### DIFF
--- a/analysis/contextual_prompt_optimizer.py
+++ b/analysis/contextual_prompt_optimizer.py
@@ -1,0 +1,54 @@
+"""Context-aware prompt optimization using dataset embeddings."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from datasets import load_dataset
+from transformers import AutoModel
+
+from .prompt_optimizer import PromptOptimizer
+
+
+class ContextualPromptOptimizer(PromptOptimizer):
+    """Optimize prompts by maximizing similarity to a dataset embedding."""
+
+    def __init__(
+        self,
+        model_name: str,
+        dataset_name: str,
+        *,
+        split: str = "train[:100]",
+        similarity_weight: float = 0.5,
+        device: Optional[str] = None,
+    ) -> None:
+        super().__init__(model_name, device=device)
+        self.embed_model = AutoModel.from_pretrained(model_name).to(self.device)
+        self.dataset_embedding = self._compute_dataset_embedding(dataset_name, split)
+        self.similarity_weight = similarity_weight
+
+    def _compute_dataset_embedding(self, dataset_name: str, split: str) -> torch.Tensor:
+        dataset = load_dataset(dataset_name, split=split)
+        texts = [r["text"] for r in dataset]
+        tokens = self.tokenizer(texts, padding=True, truncation=True, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            hidden = self.embed_model(**tokens).last_hidden_state
+            mask = tokens["attention_mask"].unsqueeze(-1)
+            pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1)
+        return pooled.mean(dim=0)
+
+    def _embedding(self, text: str) -> torch.Tensor:
+        tokens = self.tokenizer(text, return_tensors="pt").to(self.device)
+        with torch.no_grad():
+            hidden = self.embed_model(**tokens).last_hidden_state
+            mask = tokens["attention_mask"].unsqueeze(-1)
+            pooled = (hidden * mask).sum(dim=1) / mask.sum(dim=1)
+        return pooled.squeeze(0)
+
+    def score_prompt(self, prompt: str) -> float:  # type: ignore[override]
+        perplexity = super().score_prompt(prompt)
+        emb = self._embedding(prompt)
+        sim = F.cosine_similarity(emb, self.dataset_embedding, dim=0).item()
+        return perplexity - self.similarity_weight * sim

--- a/tests/test_contextual_prompt_optimizer.py
+++ b/tests/test_contextual_prompt_optimizer.py
@@ -1,0 +1,18 @@
+import torch
+from analysis.contextual_prompt_optimizer import ContextualPromptOptimizer
+from analysis.prompt_optimizer import PromptOptimizer
+from unittest.mock import patch
+
+
+def test_contextual_score_prompt():
+    with patch.object(PromptOptimizer, "__init__", return_value=None):
+        inst = object.__new__(ContextualPromptOptimizer)
+        inst.device = torch.device("cpu")
+        inst.tokenizer = None
+        inst.embed_model = None
+        inst.dataset_embedding = torch.zeros(1)
+        inst.similarity_weight = 0.5
+        with patch.object(PromptOptimizer, "score_prompt", return_value=1.0), \
+             patch.object(ContextualPromptOptimizer, "_embedding", return_value=torch.zeros(1)):
+            score = ContextualPromptOptimizer.score_prompt(inst, "test")
+    assert isinstance(score, float)

--- a/tests/test_prompt_update_callback.py
+++ b/tests/test_prompt_update_callback.py
@@ -1,0 +1,16 @@
+from analysis.prompt_optimizer import PromptOptimizer
+from train.prompt_scheduler import PromptUpdateCallback
+from transformers import TrainerState, TrainerControl
+from unittest.mock import MagicMock
+
+
+def test_prompt_update_callback():
+    opt = MagicMock(spec=PromptOptimizer)
+    opt.optimize_prompt.return_value = "new"
+    callback = PromptUpdateCallback(opt, interval=1, base_prompt="base")
+    state = TrainerState()
+    state.epoch = 0
+    control = TrainerControl()
+    callback.on_epoch_end(None, state, control)
+    opt.optimize_prompt.assert_called_with("base")
+    assert callback.current_prompt == "new"

--- a/train/prompt_scheduler.py
+++ b/train/prompt_scheduler.py
@@ -1,0 +1,29 @@
+"""Callbacks for updating prompts during training."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from transformers import TrainerCallback, TrainingArguments, TrainerState, TrainerControl
+
+from analysis.prompt_optimizer import PromptOptimizer
+
+
+class PromptUpdateCallback(TrainerCallback):
+    """Update training prompts at a fixed epoch interval."""
+
+    def __init__(self, optimizer: PromptOptimizer, *, interval: int = 1, base_prompt: str = "") -> None:
+        self.optimizer = optimizer
+        self.interval = interval
+        self.current_prompt = base_prompt
+
+    def on_epoch_end(
+        self,
+        args: TrainingArguments,
+        state: TrainerState,
+        control: TrainerControl,
+        **kwargs,
+    ) -> None:
+        if state.epoch is not None and (int(state.epoch) + 1) % self.interval == 0:
+            self.current_prompt = self.optimizer.optimize_prompt(self.current_prompt)
+            print(f"[PromptUpdateCallback] Updated prompt: {self.current_prompt}")


### PR DESCRIPTION
## Summary
- add ContextualPromptOptimizer for data-driven prompt similarity scoring
- implement PromptUpdateCallback to refine prompts during training
- allow extra callbacks in `train_model`
- include tests for new components

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a61f133b88331b7b1abbea82cfa2c